### PR TITLE
Fix case-sensitive checkout path

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This is my first Go project, so I have no fucking idea what I am doing.  Any tip
 
 ```bash
 git clone https://github.com/keith-turner/Ecoji.git
-cd ecoji
-export GOPATH=`pwd`
+cd Ecoji
+export GOPATH=$(pwd)
 go install com.github/keith-turner/cmd/decoji/ com.github/keith-turner/cmd/ecoji/
 ```
 


### PR DESCRIPTION
* Ensure that the `cd` command uses the case-sensitive name from the previous clone command
* Also, use modern, preferred POSIX command substitution over older non-POSIX backtick form for the `pwd` command