### PR TITLE
Add link to D implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Libraries [implementing](docs/encoding.md) the Ecoji encoding standard. Submit P
 
 | Language | Comments
 |----------|----------
+| [D](https://github.com/ohdatboi/ecoji-d) | Implementation of Ecoji written in the D programming language.
 | Go       | This repository offers a Go library package with two functions [ecoji.Encode()](encode.go) and [ecoji.Decode()](decode.go).
 | Java     | Coming soon, I plan to implement this and publish to maven central unless someone else does.
 


### PR DESCRIPTION
So I added a [link](https://github.com/ohdatboi/ecoji-d) my brand :new: implementation of Ecoji in D.

It's :100:% complete, both encoding and decoding. As soon as I'm done with CLI program and README it will be published on the [D package registry](http://code.dlang.org/) as well.

Also, because Ecoji encoding is not covered by any patents (I think it isn't?) ecoji-d is licensed under the MIT licence.