### PR TITLE
Added link to PHP implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Libraries [implementing](docs/encoding.md) the Ecoji encoding standard. Submit P
 |----------|----------
 | Go       | This repository offers a Go library package with two functions [ecoji.Encode()](encode.go) and [ecoji.Decode()](decode.go).
 | Java     | Coming soon, I plan to implement this and publish to maven central unless someone else does.
+| [PHP](https://github.com/Rayne/ecoji-php) | PHP 7.x implementation of Ecoji. Available as [`rayne/ecoji` on Packagist](https://packagist.org/packages/rayne/ecoji).
 
 ## Build instructions.
 


### PR DESCRIPTION
I added my PHP implementation of Ecoji/Encoji which supports encoding and decoding. The library is available at [Packagist as `rayne/ecoji`](https://packagist.org/packages/rayne/ecoji) and has a 100% test coverage.