### PR TITLE
Add a link to a Rust implementation of the standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Libraries [implementing](docs/encoding.md) the Ecoji encoding standard. Submit P
 | Go       | This repository offers a Go library package with two functions [ecoji.Encode()](encode.go) and [ecoji.Decode()](decode.go).
 | Java     | Coming soon, I plan to implement this and publish to maven central unless someone else does.
 | [PHP](https://github.com/Rayne/ecoji-php) | PHP 7.x implementation of Ecoji. Available as [`rayne/ecoji` on Packagist](https://packagist.org/packages/rayne/ecoji).
+| [Rust](https://github.com/netvl/ecoji.rs) | Implementation of Ecoji written in the Rust programming language.
 
 ## Build instructions.
 


### PR DESCRIPTION
Hello,

Recently I've got a need in an emoji-based base64-like encoding in Rust. All Rust libraries I have found were not really nice to use, so I went ahead and implemented your format in Rust. Basically, I went through your code and did almost literal translation of it to Rust, with Rust-idiomatic changes of course. It would be great if you could add a link to my library to the readme file :)

Thanks!