### PR TITLE
README.md: add .NET implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Libraries [implementing](docs/encoding.md) the Ecoji encoding standard. Submit P
 | [D](https://github.com/ohdatboi/ecoji-d) | Implementation of Ecoji written in the D programming language.
 | Go       | This repository offers a Go library package with two functions [ecoji.Encode()](encode.go) and [ecoji.Decode()](decode.go).
 | [Java](https://github.com/netvl/ecoji-java) | Implementation of Ecoji written in Java, usable in any JVM language.
+| [.NET](https://github.com/abock/dotnet-ecoji) | Implementation of Ecoji written in C# targeting .NET Standard 2.0: [`dotnet add package Ecoji`](https://www.nuget.org/packages/Ecoji).
 | [PHP](https://github.com/Rayne/ecoji-php) | PHP 7.x implementation of Ecoji. Available as [`rayne/ecoji` on Packagist](https://packagist.org/packages/rayne/ecoji).
 | [Python](https://github.com/mecforlove/ecoji-py) | Implementation of Ecoji written in the Python3 programming language.
 | [Rust](https://github.com/netvl/ecoji.rs) | Implementation of Ecoji written in the Rust programming language.


### PR DESCRIPTION
I've implemented Ecoji in C# for .NET Standard 2.0. Woo. Seems like the implementation list is sorted by language name, but it didn't feel right to push ".NET" to the top thanks to its "." prefix 😉.